### PR TITLE
Add SingletonCollectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <assertj.verseion>3.23.1</assertj.verseion>
+        <junit.version>5.9.0</junit.version>
+
         <release-plugin.version>3.0.0-M6</release-plugin.version>
         <source-plugin.version>3.2.1</source-plugin.version>
         <javadoc-plugin.version>3.2.0</javadoc-plugin.version>
@@ -65,6 +68,27 @@
         <nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.verseion}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <distributionManagement>
         <snapshotRepository>

--- a/src/main/java/io/blt/util/stream/SingletonCollectors.java
+++ b/src/main/java/io/blt/util/stream/SingletonCollectors.java
@@ -1,0 +1,108 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util.stream;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import static java.util.Collections.emptySet;
+import static java.util.Objects.nonNull;
+
+/**
+ * Implementations of {@link Collector} that reduce to exactly one or zero elements.
+ * e.g.,
+ * <pre>{@code
+ * var maybeActiveStep = sequentialSteps.stream()
+ *         .filter(SequentialStep::isActive)
+ *         .collect(SingletonCollectors.toOptional());
+ * }</pre>
+ * <p>
+ * If more than one element is present, then {@code IllegalArgumentException} is thrown.
+ */
+public final class SingletonCollectors {
+
+    private SingletonCollectors() {
+    }
+
+    private static class SingletonCollector<T, R> implements Collector<T, Container<T>, R> {
+
+        private final Function<Container<T>, R> finisher;
+
+        public SingletonCollector(Function<Container<T>, R> finisher) {
+            this.finisher = finisher;
+        }
+
+        @Override
+        public Supplier<Container<T>> supplier() {
+            return Container::new;
+        }
+
+        @Override
+        public BiConsumer<Container<T>, T> accumulator() {
+            return Container::setValue;
+        }
+
+        @Override
+        public BinaryOperator<Container<T>> combiner() {
+            return null; // Only used in a parallel stream, which this collector doesn't support
+        }
+
+        @Override
+        public Function<Container<T>, R> finisher() {
+            return finisher;
+        }
+
+        @Override
+        public Set<Characteristics> characteristics() {
+            return emptySet();
+        }
+    }
+
+    private static final class Container<T> {
+
+        private T value;
+
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            if (nonNull(this.value)) {
+                throw new IllegalStateException("Expected stream to contain exactly 0 or 1 elements");
+            }
+            this.value = value;
+        }
+
+        public Optional<T> getOptional() {
+            return Optional.ofNullable(getValue());
+        }
+    }
+
+}

--- a/src/main/java/io/blt/util/stream/SingletonCollectors.java
+++ b/src/main/java/io/blt/util/stream/SingletonCollectors.java
@@ -51,6 +51,17 @@ public final class SingletonCollectors {
     private SingletonCollectors() {
     }
 
+    /**
+     * Returns a {@code Collector} that accumulates the only element, if any, into an {@code Optional}.
+     *
+     * @param <T> the type of the input elements
+     * @return a {@code Collector} that accumulates the only element, if any, into an {@code Optional}.
+     * @throws IllegalArgumentException if more than one element is present
+     */
+    public static <T> SingletonCollector<T, Optional<T>> toOptional() {
+        return new SingletonCollector<>(Container::getOptional);
+    }
+
     private static class SingletonCollector<T, R> implements Collector<T, Container<T>, R> {
 
         private final Function<Container<T>, R> finisher;

--- a/src/main/java/io/blt/util/stream/SingletonCollectors.java
+++ b/src/main/java/io/blt/util/stream/SingletonCollectors.java
@@ -62,6 +62,17 @@ public final class SingletonCollectors {
         return new SingletonCollector<>(Container::getOptional);
     }
 
+    /**
+     * Returns a {@code Collector} that accumulates the only element, if any, into a nullable {@code Object}.
+     *
+     * @param <T> the type of the input elements
+     * @return a {@code Collector} that accumulates the only element, if any, into a nullable {@code Object}.
+     * @throws IllegalArgumentException if more than one element is present
+     */
+    public static <T> SingletonCollector<T, T> toNullable() {
+        return new SingletonCollector<>(Container::getValue);
+    }
+
     private static class SingletonCollector<T, R> implements Collector<T, Container<T>, R> {
 
         private final Function<Container<T>, R> finisher;

--- a/src/test/java/io/blt/util/stream/SingletonCollectorsTest.java
+++ b/src/test/java/io/blt/util/stream/SingletonCollectorsTest.java
@@ -1,0 +1,86 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util.stream;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+class SingletonCollectorsTest {
+
+    @Nested
+    class ToOptional {
+
+        @Test
+        void empty() {
+            var result = Stream.empty()
+                    .collect(SingletonCollectors.toOptional());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void containsSingleElement() {
+            var result = Stream.of("one")
+                    .collect(SingletonCollectors.toOptional());
+
+            assertThat(result).contains("one");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"one", "two", "three"})
+        void containsSingleFilteredElement(String filter) {
+            var result = Stream.of("one", "two", "three")
+                    .filter(filter::equals)
+                    .collect(SingletonCollectors.toOptional());
+
+            assertThat(result).contains(filter);
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.blt.util.stream.SingletonCollectorsTest#moreThanOneElement")
+        void throwsOnMoreThanOneElement(List<String> elements) {
+            assertThatIllegalStateException().isThrownBy(
+                            () -> elements.stream().collect(SingletonCollectors.toOptional())
+                    )
+                    .withMessage("Expected stream to contain exactly 0 or 1 elements");
+        }
+
+    }
+
+    private static Stream<List<String>> moreThanOneElement() {
+        return Stream.of(
+                List.of("one", "two"),
+                List.of("one", "two", "three"));
+    }
+}

--- a/src/test/java/io/blt/util/stream/SingletonCollectorsTest.java
+++ b/src/test/java/io/blt/util/stream/SingletonCollectorsTest.java
@@ -78,6 +78,45 @@ class SingletonCollectorsTest {
 
     }
 
+    @Nested
+    class ToNullable {
+
+        @Test
+        void empty() {
+            var result = Stream.empty()
+                    .collect(SingletonCollectors.toNullable());
+
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void containsSingleElement() {
+            var result = Stream.of("one")
+                    .collect(SingletonCollectors.toNullable());
+
+            assertThat(result).contains("one");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"one", "two", "three"})
+        void containsSingleFilteredElement(String filter) {
+            var result = Stream.of("one", "two", "three")
+                    .filter(filter::equals)
+                    .collect(SingletonCollectors.toNullable());
+
+            assertThat(result).contains(filter);
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.blt.util.stream.SingletonCollectorsTest#moreThanOneElement")
+        void throwsOnMoreThanOneElement(List<String> elements) {
+            assertThatIllegalStateException().isThrownBy(
+                            () -> elements.stream().collect(SingletonCollectors.toNullable()))
+                    .withMessage("Expected stream to contain exactly 0 or 1 elements")
+        }
+
+    }
+
     private static Stream<List<String>> moreThanOneElement() {
         return Stream.of(
                 List.of("one", "two"),


### PR DESCRIPTION
### Add `SingletonCollectors`

Implementations of `Collector` that reduce to exactly one or zero elements.
e.g.,
```java
var maybeActiveStep = sequentialSteps.stream()
        .filter(SequentialStep::isActive)
        .collect(SingletonCollectors.toOptional());
}
```

If more than one element is present, then `IllegalArgumentException` is thrown.