### PR TITLE
Add tap function

### DIFF
--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -40,7 +40,7 @@ public final class Obj {
      * Passes the {@code instance} to the {@code consumer}, then returns the {@code instance}.
      * e.g.
      * <pre>{@code
-     * var user = Obj.tap(new User(), u -> {
+     * var user = Obj.poke(new User(), u -> {
      *     u.setName("Greg");
      *     u.setAge(15);
      * });
@@ -51,16 +51,13 @@ public final class Obj {
      * @param <T>      type of {@code instance}
      * @return {@code instance} after accepting side effects via {@code consumer}.
      */
-    @SuppressWarnings("unchecked")
-    public static <T> T tap(T instance, Consumer<? extends T> consumer) {
-        // Unchecked cast is required to allow for <? extends T> which is a workaround to an ambiguity issue
-        // https://stackoverflow.com/a/48388275
-        ((Consumer<T>) consumer).accept(instance);
+    public static <T> T poke(T instance, Consumer<T> consumer) {
+        consumer.accept(instance);
         return instance;
     }
 
     /**
-     * Calls the {@code supplier} to retrieve an instance which is passed to the {@code consumer} then returned.
+     * Calls the {@code supplier} to retrieve an instance which is mutated by the {@code consumer} then returned.
      * e.g.
      * <pre>{@code
      * var user = Obj.tap(User::new, u -> {
@@ -74,8 +71,8 @@ public final class Obj {
      * @param <T>      type of instance
      * @return Supplied instance after applying side effects via {@code consumer}.
      */
-    public static <T> T tap(Supplier<T> supplier, Consumer<? extends T> consumer) {
-        return tap(supplier.get(), consumer);
+    public static <T> T tap(Supplier<T> supplier, Consumer<T> consumer) {
+        return poke(supplier.get(), consumer);
     }
 
 }

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -25,6 +25,7 @@
 package io.blt.util;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Static utility methods for operating on {@code Object}.
@@ -50,9 +51,31 @@ public final class Obj {
      * @param <T>      type of {@code instance}
      * @return {@code instance} after accepting side effects via {@code consumer}.
      */
-    public static <T> T tap(T instance, Consumer<T> consumer) {
-        consumer.accept(instance);
+    @SuppressWarnings("unchecked")
+    public static <T> T tap(T instance, Consumer<? extends T> consumer) {
+        // Unchecked cast is required to allow for <? extends T> which is a workaround to an ambiguity issue
+        // https://stackoverflow.com/a/48388275
+        ((Consumer<T>) consumer).accept(instance);
         return instance;
+    }
+
+    /**
+     * Calls the {@code supplier} to retrieve an instance which is passed to the {@code consumer} then returned.
+     * e.g.
+     * <pre>{@code
+     * var user = Obj.tap(User::new, u -> {
+     *     u.setName("Greg");
+     *     u.setAge(15);
+     * });
+     * }</pre>
+     *
+     * @param supplier Supplies an instance to consume and return
+     * @param consumer Operation to perform on supplied instance
+     * @param <T>      type of instance
+     * @return Supplied instance after applying side effects via {@code consumer}.
+     */
+    public static <T> T tap(Supplier<T> supplier, Consumer<? extends T> consumer) {
+        return tap(supplier.get(), consumer);
     }
 
 }

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -24,6 +24,8 @@
 
 package io.blt.util;
 
+import java.util.function.Consumer;
+
 /**
  * Static utility methods for operating on {@code Object}.
  */
@@ -31,6 +33,26 @@ public final class Obj {
 
     private Obj() {
         throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
+    }
+
+    /**
+     * Passes the {@code instance} to the {@code consumer}, then returns the {@code instance}.
+     * e.g.
+     * <pre>{@code
+     * var user = Obj.tap(new User(), u -> {
+     *     u.setName("Greg");
+     *     u.setAge(15);
+     * });
+     * }</pre>
+     *
+     * @param instance instance to consume and return
+     * @param consumer operation to perform on {@code instance}
+     * @param <T>      type of {@code instance}
+     * @return {@code instance} after accepting side effects via {@code consumer}.
+     */
+    public static <T> T tap(T instance, Consumer<T> consumer) {
+        consumer.accept(instance);
+        return instance;
     }
 
 }

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util;
+
+/**
+ * Static utility methods for operating on {@code Object}.
+ */
+public final class Obj {
+
+    private Obj() {
+        throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
+    }
+
+}

--- a/src/main/java/io/blt/util/stream/SingletonCollectors.java
+++ b/src/main/java/io/blt/util/stream/SingletonCollectors.java
@@ -49,6 +49,7 @@ import static java.util.Objects.nonNull;
 public final class SingletonCollectors {
 
     private SingletonCollectors() {
+        throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
     }
 
     /**

--- a/src/test/java/io/blt/test/AssertUtils.java
+++ b/src/test/java/io/blt/test/AssertUtils.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public final class AssertUtils {
+
+    private AssertUtils() {}
+
+    public static void assertValidUtilityClass(Class<?> clazz) throws NoSuchMethodException {
+        assertThat(clazz)
+                .withFailMessage("Utility class must be final")
+                .isFinal();
+
+        assertThat(clazz.getDeclaredConstructors())
+                .withFailMessage("Utility class must only have a zero argument constructor")
+                .hasSize(1)
+                .extracting(Constructor::getParameterCount)
+                .hasSize(1);
+
+        var constructor = clazz.getDeclaredConstructor();
+
+        assertThat(constructor.getModifiers())
+                .withFailMessage("Constructor must be private")
+                .matches(Modifier::isPrivate);
+
+        constructor.setAccessible(true);
+
+        assertThatExceptionOfType(InvocationTargetException.class)
+                .describedAs("Utility class should throw if constructed")
+                .isThrownBy(constructor::newInstance)
+                .havingCause()
+                .isInstanceOf(IllegalAccessError.class)
+                .withMessage("Utility class should be accessed statically and never constructed");
+    }
+
+}

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.blt.test.AssertUtils.assertValidUtilityClass;
+import static io.blt.util.Obj.poke;
 import static io.blt.util.Obj.tap;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,7 +47,7 @@ class ObjTest {
         void tapShouldReturnInstance() {
             var instance = new Object();
 
-            var result = tap(instance, c -> {});
+            var result = poke(instance, c -> {});
 
             assertThat(result).isEqualTo(instance);
         }
@@ -56,7 +57,7 @@ class ObjTest {
             var instance = new Object();
             var reference = new AtomicReference<>();
 
-            tap(instance, reference::set);
+            poke(instance, reference::set);
 
             var result = reference.get();
             assertThat(result).isEqualTo(instance);
@@ -64,7 +65,7 @@ class ObjTest {
 
         @Test
         void tapShouldOperateOnTheInstance() {
-            var result = tap(new User(), u -> {
+            var result = poke(new User(), u -> {
                 u.setName("Greg");
                 u.setAge(15);
             });

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -76,6 +76,45 @@ class ObjTest {
 
     }
 
+    @Nested
+    class Supplied {
+
+        @Test
+        void tapShouldReturnSuppliedInstance() {
+            var instance = new Object();
+
+            var result = tap(() -> instance, s -> {});
+
+            result = tap(() -> instance, s -> {});
+
+            assertThat(result).isEqualTo(instance);
+        }
+
+        @Test
+        void tapShouldPassSuppliedInstanceToConsumer() {
+            var instance = new Object();
+            var reference = new AtomicReference<>();
+
+            tap(() -> instance, reference::set);
+
+            var result = reference.get();
+            assertThat(result).isEqualTo(instance);
+        }
+
+        @Test
+        void tapShouldOperateOnTheSuppliedInstance() {
+            var result = tap(User::new, u -> {
+                u.setName("Greg");
+                u.setAge(15);
+            });
+
+            assertThat(result)
+                    .extracting(User::getName, User::getAge)
+                    .containsExactly("Greg", 15);
+        }
+
+    }
+
     public static class User {
         private String name;
         private Integer age;

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -24,15 +24,77 @@
 
 package io.blt.util;
 
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.blt.test.AssertUtils.assertValidUtilityClass;
+import static io.blt.util.Obj.tap;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ObjTest {
 
     @Test
     void shouldBeValidUtilityClass() throws NoSuchMethodException {
         assertValidUtilityClass(Obj.class);
+    }
+
+    @Nested
+    class Instance {
+
+        @Test
+        void tapShouldReturnInstance() {
+            var instance = new Object();
+
+            var result = tap(instance, c -> {});
+
+            assertThat(result).isEqualTo(instance);
+        }
+
+        @Test
+        void tapShouldPassInstanceToConsumer() {
+            var instance = new Object();
+            var reference = new AtomicReference<>();
+
+            tap(instance, reference::set);
+
+            var result = reference.get();
+            assertThat(result).isEqualTo(instance);
+        }
+
+        @Test
+        void tapShouldOperateOnTheInstance() {
+            var result = tap(new User(), u -> {
+                u.setName("Greg");
+                u.setAge(15);
+            });
+
+            assertThat(result)
+                    .extracting(User::getName, User::getAge)
+                    .containsExactly("Greg", 15);
+        }
+
+    }
+
+    public static class User {
+        private String name;
+        private Integer age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
     }
 
 }

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util;
+
+import org.junit.jupiter.api.Test;
+
+import static io.blt.test.AssertUtils.assertValidUtilityClass;
+
+class ObjTest {
+
+    @Test
+    void shouldBeValidUtilityClass() throws NoSuchMethodException {
+        assertValidUtilityClass(Obj.class);
+    }
+
+}

--- a/src/test/java/io/blt/util/stream/SingletonCollectorsTest.java
+++ b/src/test/java/io/blt/util/stream/SingletonCollectorsTest.java
@@ -24,19 +24,24 @@
 
 package io.blt.util.stream;
 
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.List;
-import java.util.stream.Stream;
-
+import static io.blt.test.AssertUtils.assertValidUtilityClass;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 class SingletonCollectorsTest {
+
+    @Test
+    void shouldBeValidUtilityClass() throws NoSuchMethodException {
+        assertValidUtilityClass(SingletonCollectors.class);
+    }
 
     @Nested
     class ToOptional {
@@ -44,7 +49,7 @@ class SingletonCollectorsTest {
         @Test
         void empty() {
             var result = Stream.empty()
-                    .collect(SingletonCollectors.toOptional());
+                               .collect(SingletonCollectors.toOptional());
 
             assertThat(result).isEmpty();
         }
@@ -52,7 +57,7 @@ class SingletonCollectorsTest {
         @Test
         void containsSingleElement() {
             var result = Stream.of("one")
-                    .collect(SingletonCollectors.toOptional());
+                               .collect(SingletonCollectors.toOptional());
 
             assertThat(result).contains("one");
         }
@@ -61,8 +66,8 @@ class SingletonCollectorsTest {
         @ValueSource(strings = {"one", "two", "three"})
         void containsSingleFilteredElement(String filter) {
             var result = Stream.of("one", "two", "three")
-                    .filter(filter::equals)
-                    .collect(SingletonCollectors.toOptional());
+                               .filter(filter::equals)
+                               .collect(SingletonCollectors.toOptional());
 
             assertThat(result).contains(filter);
         }
@@ -70,9 +75,8 @@ class SingletonCollectorsTest {
         @ParameterizedTest
         @MethodSource("io.blt.util.stream.SingletonCollectorsTest#moreThanOneElement")
         void throwsOnMoreThanOneElement(List<String> elements) {
-            assertThatIllegalStateException().isThrownBy(
-                            () -> elements.stream().collect(SingletonCollectors.toOptional())
-                    )
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> elements.stream().collect(SingletonCollectors.toOptional()))
                     .withMessage("Expected stream to contain exactly 0 or 1 elements");
         }
 
@@ -84,7 +88,7 @@ class SingletonCollectorsTest {
         @Test
         void empty() {
             var result = Stream.empty()
-                    .collect(SingletonCollectors.toNullable());
+                               .collect(SingletonCollectors.toNullable());
 
             assertThat(result).isNull();
         }
@@ -92,7 +96,7 @@ class SingletonCollectorsTest {
         @Test
         void containsSingleElement() {
             var result = Stream.of("one")
-                    .collect(SingletonCollectors.toNullable());
+                               .collect(SingletonCollectors.toNullable());
 
             assertThat(result).contains("one");
         }
@@ -101,8 +105,8 @@ class SingletonCollectorsTest {
         @ValueSource(strings = {"one", "two", "three"})
         void containsSingleFilteredElement(String filter) {
             var result = Stream.of("one", "two", "three")
-                    .filter(filter::equals)
-                    .collect(SingletonCollectors.toNullable());
+                               .filter(filter::equals)
+                               .collect(SingletonCollectors.toNullable());
 
             assertThat(result).contains(filter);
         }
@@ -110,8 +114,8 @@ class SingletonCollectorsTest {
         @ParameterizedTest
         @MethodSource("io.blt.util.stream.SingletonCollectorsTest#moreThanOneElement")
         void throwsOnMoreThanOneElement(List<String> elements) {
-            assertThatIllegalStateException().isThrownBy(
-                            () -> elements.stream().collect(SingletonCollectors.toNullable()))
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> elements.stream().collect(SingletonCollectors.toNullable()))
                     .withMessage("Expected stream to contain exactly 0 or 1 elements");
         }
 


### PR DESCRIPTION
Adds `Obj`, a collection of utility for operating on `Object`. 
Currently the only methods are `tap` and `poke` which return an instance after it has been operated on by a `Consumer` - the difference being that `tap` operates on a `Consumer` and `poke` operates on an instance.
e.g.

```java
var user = Obj.tap(User::new, u -> {
    u.setName("Greg");
    u.setAge(15);
});
```

```java
var user = Obj.poke(new User(), u -> {
    u.setName("Greg");
    u.setAge(15);
});
```