### PR TITLE
Add orElseGet to Obj

### DIFF
--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -24,8 +24,11 @@
 
 package io.blt.util;
 
+import io.blt.util.functional.ThrowingSupplier;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import static java.util.Objects.nonNull;
 
 /**
  * Static utility methods for operating on {@code Object}.
@@ -73,6 +76,29 @@ public final class Obj {
      */
     public static <T> T tap(Supplier<T> supplier, Consumer<T> consumer) {
         return poke(supplier.get(), consumer);
+    }
+
+    /**
+     * Returns {@code value} if non-null, else invokes and returns the result of {@code supplier}.
+     * <p>
+     * Optionally, the {@code supplier} may throw which will bubble up.
+     * </p>
+     * e.g.
+     * <pre>{@code
+     * private URL homepageOrDefault(URL homepage) throws MalformedURLException {
+     *     return orElseGet(homepage, () -> new URL("https://google.com"));
+     * }
+     * }</pre>
+     *
+     * @param value    Returned if non-null
+     * @param supplier Called and returned if {@code value} is null
+     * @param <T>      Type of the returned value
+     * @param <E>      Type of {@code supplier} throwable
+     * @return {@code value} if non-null, the result of {@code supplier}
+     * @throws E {@code Throwable} that may be thrown if the {@code supplier} is invoked
+     */
+    public static <T, E extends Throwable> T orElseGet(T value, ThrowingSupplier<T, E> supplier) throws E {
+        return nonNull(value) ? value : supplier.get();
     }
 
 }

--- a/src/main/java/io/blt/util/functional/ThrowingSupplier.java
+++ b/src/main/java/io/blt/util/functional/ThrowingSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util.functional;
+
+/**
+ * Represents a supplier of results that may throw.
+ *
+ * @param <T> the type of results supplied by this supplier
+ * @param <E> the type of {@code Throwable} that may be thrown by this supplier
+ */
+@FunctionalInterface
+public interface ThrowingSupplier<T, E extends Throwable> {
+
+    /**
+     * Returns a result.
+     *
+     * @return a result
+     * @throws E {@code Throwable} that may be thrown
+     */
+    T get() throws E;
+}

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -29,9 +29,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.blt.test.AssertUtils.assertValidUtilityClass;
+import static io.blt.util.Obj.orElseGet;
 import static io.blt.util.Obj.poke;
 import static io.blt.util.Obj.tap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 
 class ObjTest {
 
@@ -114,6 +116,33 @@ class ObjTest {
                     .containsExactly("Greg", 15);
         }
 
+    }
+
+    @Test
+    void orElseGetShouldReturnValueIfNonNull() {
+        var value = "Phil";
+
+        var result = orElseGet(value, () -> null);
+
+        assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    void orElseGetShouldReturnSupplierResultIfValueIsNonNull() {
+        var value = "Louis";
+
+        var result = orElseGet(null, () -> value);
+
+        assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    void orElseGetShouldBubbleUpSupplierThrowable() {
+        var exception = new Exception("mock exception");
+
+        assertThatException()
+                .isThrownBy(() -> orElseGet(null, () -> {throw exception;}))
+                .isEqualTo(exception);
     }
 
     public static class User {


### PR DESCRIPTION
Performs an operation similar to `Optional#orElseGet` but supports suppliers that throw e.g.

This is not possible with `Optional`:
```java
// Unhandled exception java.net.MalformedURLException
return Optional.ofNullable(homepage)
        .orElseGet(() -> new URL("https://google.com"));
```
But is simple using `Obj.orElseGet`:
```java
return orElseGet(homepage, () -> new URL("https://google.com"));
```
