### PR TITLE
Add ThrowingConsumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ e.g., to add the core library to your dependencies:
 
 #### `tap` and `poke`
 
-Return a passed or supplied value after mutating via a consumer.
+Return a passed or supplied value after mutating via a (throwing) consumer.
 
 These can be handy when building an object without the need of a helper method:
 
@@ -47,6 +47,8 @@ Or mutating an object to be passed as a parameter without the noise of a tempora
 ```java
 repository.persist(Obj.poke(user, u -> u.createDate(now())));
 ```
+
+Any exception thrown by a consumer will bubble up and be thrown by `tap` or `poke`.
 
 #### `orElseGet`
 

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -24,8 +24,8 @@
 
 package io.blt.util;
 
+import io.blt.util.functional.ThrowingConsumer;
 import io.blt.util.functional.ThrowingSupplier;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static java.util.Objects.nonNull;
@@ -48,13 +48,17 @@ public final class Obj {
      *     u.setAge(15);
      * });
      * }</pre>
+     * <p>
+     * Optionally, the {@code consumer} may throw which will bubble up.
+     * </p>
      *
      * @param instance instance to consume and return
      * @param consumer operation to perform on {@code instance}
      * @param <T>      type of {@code instance}
+     * @param <E>      type of {@code consumer} throwable
      * @return {@code instance} after accepting side effects via {@code consumer}.
      */
-    public static <T> T poke(T instance, Consumer<T> consumer) {
+    public static <T, E extends Throwable> T poke(T instance, ThrowingConsumer<T, E> consumer) throws E {
         consumer.accept(instance);
         return instance;
     }
@@ -68,13 +72,17 @@ public final class Obj {
      *     u.setAge(15);
      * });
      * }</pre>
+     * <p>
+     * Optionally, the {@code consumer} may throw which will bubble up.
+     * </p>
      *
-     * @param supplier Supplies an instance to consume and return
-     * @param consumer Operation to perform on supplied instance
+     * @param supplier supplies an instance to consume and return
+     * @param consumer operation to perform on supplied instance
      * @param <T>      type of instance
+     * @param <E>      type of {@code consumer} throwable
      * @return Supplied instance after applying side effects via {@code consumer}.
      */
-    public static <T> T tap(Supplier<T> supplier, Consumer<T> consumer) {
+    public static <T, E extends Throwable> T tap(Supplier<T> supplier, ThrowingConsumer<T, E> consumer) throws E {
         return poke(supplier.get(), consumer);
     }
 
@@ -90,10 +98,10 @@ public final class Obj {
      * }
      * }</pre>
      *
-     * @param value    Returned if non-null
-     * @param supplier Called and returned if {@code value} is null
-     * @param <T>      Type of the returned value
-     * @param <E>      Type of {@code supplier} throwable
+     * @param value    returned if non-null
+     * @param supplier called and returned if {@code value} is null
+     * @param <T>      type of the returned value
+     * @param <E>      type of {@code supplier} throwable
      * @return {@code value} if non-null, the result of {@code supplier}
      * @throws E {@code Throwable} that may be thrown if the {@code supplier} is invoked
      */

--- a/src/main/java/io/blt/util/functional/ThrowingConsumer.java
+++ b/src/main/java/io/blt/util/functional/ThrowingConsumer.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util.functional;
+
+/**
+ * Represents an operation that accepts a single input argument that may throw.
+ *
+ * @param <T> the type of argument consumed by this consumer
+ * @param <E> the type of {@code Throwable} that may be thrown by this consumer
+ */
+@FunctionalInterface
+public interface ThrowingConsumer<T, E extends Throwable> {
+
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param t the input argument
+     * @throws E {@code Throwable} that may be thrown
+     */
+    void accept(T t) throws E;
+
+}

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -46,7 +46,7 @@ class ObjTest {
     class Instance {
 
         @Test
-        void tapShouldReturnInstance() {
+        void pokeShouldReturnInstance() {
             var instance = new Object();
 
             var result = poke(instance, c -> {});
@@ -55,7 +55,7 @@ class ObjTest {
         }
 
         @Test
-        void tapShouldPassInstanceToConsumer() {
+        void pokeShouldPassInstanceToConsumer() {
             var instance = new Object();
             var reference = new AtomicReference<>();
 
@@ -66,7 +66,7 @@ class ObjTest {
         }
 
         @Test
-        void tapShouldOperateOnTheInstance() {
+        void pokeShouldOperateOnTheInstance() {
             var result = poke(new User(), u -> {
                 u.setName("Greg");
                 u.setAge(15);

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -24,6 +24,7 @@
 
 package io.blt.util;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,15 @@ class ObjTest {
                     .containsExactly("Greg", 15);
         }
 
+        @Test
+        void pokeShouldBubbleUpAnyExceptionsThrownByConsumer() {
+            var exception = new IOException("mock checked exception");
+
+            assertThatException()
+                    .isThrownBy(() -> poke(new User(), u -> {throw exception;}))
+                    .isEqualTo(exception);
+        }
+
     }
 
     @Nested
@@ -114,6 +124,15 @@ class ObjTest {
             assertThat(result)
                     .extracting(User::getName, User::getAge)
                     .containsExactly("Greg", 15);
+        }
+
+        @Test
+        void tapShouldBubbleUpAnyExceptionsThrownByConsumer() {
+            var exception = new IOException("mock checked exception");
+
+            assertThatException()
+                    .isThrownBy(() -> tap(User::new, u -> {throw exception;}))
+                    .isEqualTo(exception);
         }
 
     }


### PR DESCRIPTION
Adds a consumer equivalent to `ThrowingConsumer`.

Also updates `Obj.poke` and `Obj.tap` to use `ThrowingConsumer`, which will allow checked exceptions to bubble up e.g. 
```java
var user = Obj.tap(User::new, u -> {
    u.setHomePage(new URL("https://google.com"));
});
```