### PR TITLE
Add orElseOnException to Obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,26 @@ Any exception thrown by a consumer will bubble up and be thrown by `tap` or `pok
 
 #### `orElseGet`
 
-Returns a passed value if non-null otherwise invokes and returns the result of (throwing) supplier.
+Returns a passed value if non-null, otherwise invokes and returns the result of a (throwing) supplier.
 
 This is very similar to `Optional.ofNullable(...).orElseGet(...)` but more concise and supports suppliers that throw:
 
 ```java
 private URL homepageOrDefault(URL homepage) throws MalformedURLException {
     return Obj.orElseGet(homepage, () -> new URL("https://google.com"));
+}
+```
+
+#### `orElseOnException`
+
+Invokes and returns the result of a supplier, unless it throws an exception, in which case a passed value is returned. 
+e.g.
+
+```java
+private InputStream openFileOrResource(String name) {
+    return orElseOnException(
+            () -> new FileInputStream(name),
+            getClass().getResourceAsStream(name));
 }
 ```
 

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -102,11 +102,32 @@ public final class Obj {
      * @param supplier called and returned if {@code value} is null
      * @param <T>      type of the returned value
      * @param <E>      type of {@code supplier} throwable
-     * @return {@code value} if non-null, the result of {@code supplier}
+     * @return {@code value} if non-null, else the result of {@code supplier}
      * @throws E {@code Throwable} that may be thrown if the {@code supplier} is invoked
      */
     public static <T, E extends Throwable> T orElseGet(T value, ThrowingSupplier<T, E> supplier) throws E {
         return nonNull(value) ? value : supplier.get();
+    }
+
+    /**
+     * Invokes and returns the result of {@code supplier} if no exception is thrown, else returns {@code defaultValue}.
+     * e.g.
+     * <pre>{@code
+     * private InputStream openFileOrResource(String name) {
+     *     return orElseOnException(
+     *             () -> new FileInputStream(name),
+     *             getClass().getResourceAsStream(name));
+     * }
+     * }</pre>
+     *
+     * @param supplier        called and returned if no exception is thrown
+     * @param defaultValue    returned if an exception is thrown when calling {@code supplier}
+     * @param <T>             type of the returned value
+     * @param <E>             type of {@code supplier} throwable
+     * @return result of {@code supplier} if no exception is thrown, else {@code defaultValue}
+     */
+    public static <T, E extends Throwable> T orElseOnException(ThrowingSupplier<T, E> supplier, T defaultValue) {
+        return supplier.orOnException(defaultValue);
     }
 
 }

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.blt.test.AssertUtils.assertValidUtilityClass;
 import static io.blt.util.Obj.orElseGet;
+import static io.blt.util.Obj.orElseOnException;
 import static io.blt.util.Obj.poke;
 import static io.blt.util.Obj.tap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -162,6 +163,24 @@ class ObjTest {
         assertThatException()
                 .isThrownBy(() -> orElseGet(null, () -> {throw exception;}))
                 .isEqualTo(exception);
+    }
+
+    @Test
+    void orElseOnExceptionShouldReturnSupplierResultIfNoExceptionIsThrown() {
+        var supplierResult = "Greg";
+
+        var result = orElseOnException(() -> supplierResult, null);
+
+        assertThat(result).isEqualTo(supplierResult);
+    }
+
+    @Test
+    void orElseOnExceptionShouldReturnValueIfExceptionIsThrown() {
+        var value = "Sven";
+
+        var result = orElseOnException(() -> {throw new Exception("mock exception");}, value);
+
+        assertThat(result).isEqualTo(value);
     }
 
     public static class User {

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -147,12 +147,12 @@ class ObjTest {
     }
 
     @Test
-    void orElseGetShouldReturnSupplierResultIfValueIsNonNull() {
-        var value = "Louis";
+    void orElseGetShouldReturnSupplierResultIfValueIsNull() {
+        var supplierResult = "Louis";
 
-        var result = orElseGet(null, () -> value);
+        var result = orElseGet(null, () -> supplierResult);
 
-        assertThat(result).isEqualTo(value);
+        assertThat(result).isEqualTo(supplierResult);
     }
 
     @Test

--- a/src/test/java/io/blt/util/functional/ThrowingSupplierTest.java
+++ b/src/test/java/io/blt/util/functional/ThrowingSupplierTest.java
@@ -24,36 +24,30 @@
 
 package io.blt.util.functional;
 
-import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
 
-/**
- * Represents a supplier of results that may throw.
- *
- * @param <T> the type of results supplied by this supplier
- * @param <E> the type of {@code Throwable} that may be thrown by this supplier
- */
-@FunctionalInterface
-public interface ThrowingSupplier<T, E extends Throwable> {
+import static org.assertj.core.api.Assertions.assertThat;
 
-    /**
-     * Returns a result.
-     *
-     * @return a result
-     * @throws E {@code Throwable} that may be thrown
-     */
-    T get() throws E;
+class ThrowingSupplierTest {
 
-    /**
-     * Returns the result of {@link ThrowingSupplier#get()} if no exception is thrown, else returns {@code value}.
-     *
-     * @param value returned if an exception is thrown when calling {@link ThrowingSupplier#get()}
-     * @return result of {@link ThrowingSupplier#get()} if no exception is thrown, else {@code value}
-     */
-    default T orOnException(T value) {
-        try {
-            return get();
-        } catch (Throwable e) {
-            return value;
-        }
+    @Test
+    void orOnExceptionShouldReturnSupplierResultIfNoExceptionIsThrown() {
+        var supplierResult = "Greg";
+
+        ThrowingSupplier<String, Exception> supplier = () -> supplierResult;
+        var result = supplier.orOnException(null);
+
+        assertThat(result).isEqualTo(supplierResult);
     }
+
+    @Test
+    void orOnExceptionShouldReturnValueIfExceptionIsThrown() {
+        var value = "Greg";
+
+        ThrowingSupplier<String, Exception> supplier = () -> {throw new Exception("mock exception");};
+        var result = supplier.orOnException(value);
+
+        assertThat(result).isEqualTo(value);
+    }
+
 }


### PR DESCRIPTION
Provides a method which effectively performs the same as the following code:

```java
try {
    supplier.get();
} catch (Exception ignored) {
    return defaultValue;
}
```

This can be quite useful when a fallback (or potential fallback) is available e.g.

```java
private InputStream openFileOrResource(String name) {
    return orElseOnException(
            () -> new FileInputStream(name),
            getClass().getResourceAsStream(name));
}
```