### PR TITLE
Fix warning 'exposed outside visibility scope' in SingletonCollector

### DIFF
--- a/src/main/java/io/blt/util/stream/SingletonCollectors.java
+++ b/src/main/java/io/blt/util/stream/SingletonCollectors.java
@@ -74,11 +74,11 @@ public final class SingletonCollectors {
         return new SingletonCollector<>(Container::getValue);
     }
 
-    private static class SingletonCollector<T, R> implements Collector<T, Container<T>, R> {
+    public static final class SingletonCollector<T, R> implements Collector<T, Container<T>, R> {
 
         private final Function<Container<T>, R> finisher;
 
-        public SingletonCollector(Function<Container<T>, R> finisher) {
+        private SingletonCollector(Function<Container<T>, R> finisher) {
             this.finisher = finisher;
         }
 
@@ -108,9 +108,11 @@ public final class SingletonCollectors {
         }
     }
 
-    private static final class Container<T> {
+    public static final class Container<T> {
 
         private T value;
+
+        private Container() {}
 
         public T getValue() {
             return value;

--- a/src/test/java/io/blt/test/AssertUtils.java
+++ b/src/test/java/io/blt/test/AssertUtils.java
@@ -62,4 +62,15 @@ public final class AssertUtils {
                 .withMessage("Utility class should be accessed statically and never constructed");
     }
 
+    public static void assertValidExposedPrivateImplementationClass(Class<?> clazz) {
+        assertThat(clazz)
+                .isFinal()
+                .isPublic();
+
+        assertThat(clazz.getConstructors())
+                .describedAs("All constructors must be private")
+                .extracting(Constructor::getModifiers)
+                .allMatch(Modifier::isPrivate);
+    }
+
 }

--- a/src/test/java/io/blt/util/stream/SingletonCollectorsTest.java
+++ b/src/test/java/io/blt/util/stream/SingletonCollectorsTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static io.blt.test.AssertUtils.assertValidExposedPrivateImplementationClass;
 import static io.blt.test.AssertUtils.assertValidUtilityClass;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -41,6 +42,12 @@ class SingletonCollectorsTest {
     @Test
     void shouldBeValidUtilityClass() throws NoSuchMethodException {
         assertValidUtilityClass(SingletonCollectors.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {SingletonCollectors.SingletonCollector.class, SingletonCollectors.Container.class})
+    void shouldBeValidExposedPrivateImplementationClass(Class<?> clazz) {
+        assertValidExposedPrivateImplementationClass(clazz);
     }
 
     @Nested


### PR DESCRIPTION
Fixes a warning in `SingletonCollector`:
```
Class 'SingletonCollector<T, T>' is exposed outside its defined visibility scope
```

This is caused by the fact that the class is both `private` and returned by a `public` method e.g. `toNullable()`.
The nested classes were made `private` as they are implementation detail and not designed to be used elsewhere.

The fix is to make these classes `public` (they are after all returned) but with `private` constructors to stop them being used elsewhere. I added a helper method to assert this case - `assertValidExposedPrivateImplementationClass`.