### PR TITLE
Add transformValues to Ctr

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ e.g., to add the core library to your dependencies:
 
 ### `Obj`
 
+> Static utility methods for operating on `Object`
+
 #### `tap` and `poke`
 
 Return a passed or supplied value after mutating via a (throwing) consumer.
@@ -83,6 +85,24 @@ Creates a new instance of the same type as the input object if possible, otherwi
 public <K, V> Map<K, V> mapOfSameTypeOrHashMap(Map<K, V> map) {
     return newInstanceOf(map).orElse(new HashMap<>());
 }
+```
+
+### `Ctr`
+
+> Static utility methods for operating on `Collection`
+> 
+> For methods that accept and return a container, the result will be of the [same type if possible](#newInstanceOf)
+
+#### `transformValues`
+
+Returns a new `Map` containing the entries of another with a transform applied to the values. 
+If possible, the returned `Map` is of the same type as the passed `Map`.
+e.g.
+
+```java
+var birthdays = transformValues(
+        Map.of("Greg", Month.NOVEMBER, "Phil", Month.OCTOBER, "Louis", Month.FEBRUARY), 
+        e -> e.getDisplayName(TextStyle.FULL, Locale.ENGLISH));
 ```
 
 ### `SingletonCollectors`

--- a/src/main/java/io/blt/util/Ctr.java
+++ b/src/main/java/io/blt/util/Ctr.java
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util;
+
+import io.blt.util.functional.ThrowingFunction;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.blt.util.Obj.newInstanceOf;
+
+/**
+ * Static utility methods for operating on implementations of {@code Collection} i.e. containers.
+ * <p>
+ * For methods that return a modification of a passed collection, the result will be of the same type if possible.
+ * This is accomplished using {@link Obj#newInstanceOf(Object)} and its limitations apply.
+ * </p>
+ */
+public final class Ctr {
+
+    private Ctr() {
+        throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
+    }
+
+    /**
+     * Returns a new {@link Map} containing the entries of {@code source} with {@code transform} applied to the values.
+     * <p>
+     * If possible, the result is of the same type as the passed {@code source} map.
+     * </p>
+     * e.g.
+     * <pre>{@code
+     * var scores = Map.of("Louis", 95, "Greg", 92, "Mike", 71, "Phil", 86);
+     * var grades = transformValues(scores, score -> {
+     *     if (score >= 90) {
+     *         return "A";
+     *     } else if (score >= 80) {
+     *         return "B";
+     *     } else if (score >= 70) {
+     *         return "C";
+     *     } else if (score >= 60) {
+     *         return "D";
+     *     } else {
+     *         return "F";
+     *     }
+     * });
+     * // grades = Map.of("Louis", "A", "Greg", "A", "Mike", "C", "Phil", "B")
+     * }</pre>
+     *
+     * @param source    {@link Map} whose values should be transformed
+     * @param transform value transformation function
+     * @param <K>       {@code map} key type
+     * @param <V>       {@code map} value type
+     * @param <R>       returned map value type
+     * @param <E>       type of {@code transform} throwable
+     * @return a new {@link Map} containing the entries of {@code source} with {@code transform} applied to the values
+     * @see Obj#newInstanceOf(Object)
+     */
+    @SuppressWarnings("unchecked")
+    public static <K, V, R, E extends Throwable> Map<K, R> transformValues(
+            Map<K, V> source, ThrowingFunction<? super V, R, E> transform) throws E {
+        var result = newInstanceOf((Map<K, R>) source).orElse(new DefaultMap<>());
+
+        for (var entry : source.entrySet()) {
+            result.put(entry.getKey(), transform.apply(entry.getValue()));
+        }
+
+        return result instanceof DefaultMap ? Map.copyOf(result) : result;
+    }
+
+    private static final class DefaultMap<K, V> extends HashMap<K, V> {}
+
+}

--- a/src/main/java/io/blt/util/functional/ThrowingFunction.java
+++ b/src/main/java/io/blt/util/functional/ThrowingFunction.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util.functional;
+
+/**
+ * Represents a function that may throw and accepts one argument and produces a result.
+ *
+ * @param <T> the type of argument consumed by this function
+ * @param <R> the type of results returned by this function
+ * @param <E> the type of {@code Throwable} that may be thrown by this function
+ */
+@FunctionalInterface
+public interface ThrowingFunction<T, R, E extends Throwable> {
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param t the function argument
+     * @return the function result
+     * @throws E {@code Throwable} that may be thrown
+     */
+    R apply(T t) throws E;
+
+}

--- a/src/test/java/io/blt/util/CtrTest.java
+++ b/src/test/java/io/blt/util/CtrTest.java
@@ -1,0 +1,104 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util;
+
+import java.time.Month;
+import java.time.format.TextStyle;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static io.blt.test.AssertUtils.assertValidUtilityClass;
+import static io.blt.util.Ctr.transformValues;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class CtrTest {
+
+    static final Map<String, Month> MAP = Map.of(
+            "Mike", Month.JUNE, "Greg", Month.NOVEMBER, "Phil", Month.OCTOBER, "Louis", Month.FEBRUARY);
+
+    @Test
+    void shouldBeValidUtilityClass() throws NoSuchMethodException {
+        assertValidUtilityClass(Ctr.class);
+    }
+
+    static Stream<Map<String, Month>> transformValuesShouldReturnNewMapOfSameTypeContainingTransformedValues() {
+        return Stream.of(MAP, new HashMap<>(MAP), new LinkedHashMap<>(MAP), new TreeMap<>(MAP));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void transformValuesShouldReturnNewMapOfSameTypeContainingTransformedValues(Map<String, Month> map) {
+        var result = transformValues(map, e -> e.getDisplayName(TextStyle.FULL, Locale.ENGLISH));
+
+        assertThat(result)
+                .isNotEqualTo(map)
+                .hasSameClassAs(map)
+                .containsOnly(
+                        entry("Mike", "June"),
+                        entry("Greg", "November"),
+                        entry("Phil", "October"),
+                        entry("Louis", "February"));
+    }
+
+    static Stream<Map<?, ?>> transformValuesShouldReturnEmptyMapOfSameType() {
+        return Stream.of(Map.of(), new HashMap<>(), new LinkedHashMap<>(), new TreeMap<>());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void transformValuesShouldReturnEmptyMapOfSameType(Map<String, Month> map) {
+        var result = transformValues(map, e -> { throw new IllegalStateException(); });
+
+        assertThat(result)
+                .hasSameClassAs(map)
+                .isEmpty();
+    }
+
+    @Test
+    void transformValuesShouldThrowWhenMapIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> transformValues(null, e -> e));
+    }
+
+    @Test
+    void transformValuesShouldBubbleUpExceptionThrownByTransformationFunction() {
+        var exception = new Exception();
+
+        assertThatException()
+                .isThrownBy(() -> transformValues(Map.of("hello", "Worf"), e -> { throw exception; }))
+                .isEqualTo(exception);
+    }
+
+}


### PR DESCRIPTION
Returns a new `Map` containing the entries of another with a transform applied to the values. 
If possible, the returned `Map` is of the same type as the passed `Map`.
e.g.

```java
var birthdays = transformValues(
        Map.of("Greg", Month.NOVEMBER, "Phil", Month.OCTOBER, "Louis", Month.FEBRUARY), 
        e -> e.getDisplayName(TextStyle.FULL, Locale.ENGLISH));
```