### PR TITLE
Add throwIf and throwUnless to Obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ private InputStream openFileOrResource(String name) {
 }
 ```
 
+#### `throwIf` and `throwUnless`
+
+Throws a provided exception if the given `value` satisfies (or doesn't satisfy) the provided `predicate`.
+e.g.
+
+```java
+public Map<String, String> loadProperties() {
+    return throwIf(Properties.loadFromJson(FILENAME), Map::isEmpty,
+            () -> new IllegalStateException("Properties must not be empty"));
+}
+```
+
 #### `newInstanceOf`
 
 Creates a new instance of the same type as the input object if possible, otherwise, returns empty. e.g.

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -44,6 +44,8 @@ import static io.blt.util.Obj.orElseGet;
 import static io.blt.util.Obj.orElseOnException;
 import static io.blt.util.Obj.poke;
 import static io.blt.util.Obj.tap;
+import static io.blt.util.Obj.throwIf;
+import static io.blt.util.Obj.throwUnless;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -192,6 +194,44 @@ class ObjTest {
         var result = orElseOnException(() -> {throw new Exception("mock exception");}, value);
 
         assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    void throwIfShouldThrowWhenPredicateIsTrue() {
+        var exception = new Exception("mock exception");
+
+        assertThatException()
+                .isThrownBy(() -> throwIf(null, v -> true, () -> exception))
+                .isEqualTo(exception);
+    }
+
+    @Test
+    void throwIfShouldReturnValueWhenPredicateIsFalse() throws Exception {
+        var value = "mock value";
+
+        var result = throwIf(value, v -> false, () -> new Exception("mock exception"));
+
+        assertThat(result)
+                .isEqualTo(value);
+    }
+
+    @Test
+    void throwUnlessShouldThrowWhenPredicateIsFalse() {
+        var exception = new Exception("mock exception");
+
+        assertThatException()
+                .isThrownBy(() -> throwUnless(null, v -> false, () -> exception))
+                .isEqualTo(exception);
+    }
+
+    @Test
+    void throwUnlessShouldReturnValueWhenPredicateIsTrue() throws Exception {
+        var value = "mock value";
+
+        var result = throwUnless(value, v -> true, () -> new Exception("mock exception"));
+
+        assertThat(result)
+                .isEqualTo(value);
     }
 
     static Stream<Arguments> newInstanceOfShouldReturnNewInstanceOf() {


### PR DESCRIPTION
Allows throwing when a predicate is (or is not) satisfied by a provided value.
The provided value is also returned allowing for very readable conditional exceptions e.g.

```java
public Map<String, String> loadProperties() {
    return throwIf(Properties.loadFromJson(FILENAME), Map::isEmpty,
            () -> new IllegalStateException("Properties must not be empty"));
}
```