### PR TITLE
Add computeIfAbsent to Ctr

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,33 @@ var birthdays = Ctr.transformValues(
 
 Computes a value for a `Map` if one is not currently present and returns the value.
 
-This is very similar to `map.computeIfAbsent(key, compute)` but supports a function that throws:
+This is very similar to `map.computeIfAbsent(key, compute)` but supports a Function that throws:
 
 ```java
 private final Map<URL, String> cache = new HashMap<>();
 
 public String fetch(URL url) throws IOException {
     return Ctr.computeIfAbsent(cache, url, this::get);
+}
+
+private String get(URL url) throws IOException {
+    try (var stream = url.openStream()) {
+        return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+}
+```
+
+As well as a Supplier that throws:
+
+```java
+private final Map<URL, String> cache = new HashMap<>();
+
+public String fetch(URL url) throws IOException {
+    return Ctr.computeIfAbsent(cache, url, () -> {
+        try (var stream = url.openStream()) {
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    });
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ var birthdays = Ctr.transformValues(
         e -> e.getDisplayName(TextStyle.FULL, Locale.ENGLISH));
 ```
 
+#### `computeIfAbsent`
+
+Computes a value for a `Map` if one is not currently present and returns the value.
+
+This is very similar to `map.computeIfAbsent(key, compute)` but supports a function that throws:
+
+```java
+private final Map<URL, String> cache = new HashMap<>();
+
+public String fetch(URL url) throws IOException {
+    return Ctr.computeIfAbsent(cache, url, this::get);
+}
+```
+
 ### `SingletonCollectors`
 
 Implementations of `Collector` that reduce to exactly one or zero elements.

--- a/src/test/java/io/blt/util/CtrTest.java
+++ b/src/test/java/io/blt/util/CtrTest.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -103,62 +104,130 @@ class CtrTest {
                 .isEqualTo(exception);
     }
 
-    @Test
-    void computeIfAbsentShouldReturnValueAndNotModifyMapWhenValueIsPresent() {
-        var entries = Map.of("Link", "Master Sword");
-        var map = new HashMap<>(entries);
+    @Nested
+    class UsingFunction {
 
-        var result = computeIfAbsent(map, "Link", x -> fail("Should not have executed compute function"));
+        @Test
+        void computeIfAbsentShouldReturnValueAndNotModifyMapWhenValueIsPresent() {
+            var entries = Map.of("Link", "Master Sword");
+            var map = new HashMap<>(entries);
 
-        assertThat(result)
-                .isEqualTo("Master Sword");
+            var result = computeIfAbsent(map, "Link", x -> fail("Should not have executed compute function"));
 
-        assertThat(map)
-                .containsExactlyEntriesOf(entries);
+            assertThat(result)
+                    .isEqualTo("Master Sword");
+
+            assertThat(map)
+                    .containsExactlyEntriesOf(entries);
+        }
+
+        @Test
+        void computeIfAbsentShouldComputeAndReturnValueAndModifyMapWhenValueIsNotPresent() {
+            var entries = Map.of("Link", "Master Sword");
+            var map = new HashMap<>(entries);
+
+            var result = computeIfAbsent(map, "Mario", x -> "Super Mushroom");
+
+            assertThat(result)
+                    .isEqualTo("Super Mushroom");
+
+            assertThat(map)
+                    .hasSize(2)
+                    .containsAllEntriesOf(entries)
+                    .containsEntry("Mario", "Super Mushroom");
+        }
+
+        @Test
+        void computeIfAbsentShouldReturnNullAndNotModifyMapWhenComputeReturnsNull() {
+            var entries = Map.of("Link", "Master Sword");
+            var map = new HashMap<>(entries);
+
+            var result = computeIfAbsent(map, "Mario", x -> null);
+
+            assertThat(result)
+                    .isNull();
+
+            assertThat(map)
+                    .containsExactlyEntriesOf(entries);
+        }
+
+        @Test
+        void computeIfAbsentShouldBubbleUpExceptionAndNotModifyMapWhenComputeThrows() {
+            var entries = Map.of("Link", "Master Sword");
+            var map = new HashMap<>(entries);
+            var exception = new Exception("Mock exception");
+
+            assertThatException()
+                    .isThrownBy(() -> computeIfAbsent(map, "Mario", x -> {throw exception;}))
+                    .isEqualTo(exception);
+
+            assertThat(map)
+                    .containsExactlyEntriesOf(entries);
+        }
+
     }
 
-    @Test
-    void computeIfAbsentShouldComputeAndReturnValueAndModifyMapWhenValueIsNotPresent() {
-        var entries = Map.of("Link", "Master Sword");
-        var map = new HashMap<>(entries);
+    @Nested
+    class UsingSupplier {
 
-        var result = computeIfAbsent(map, "Mario", x -> "Super Mushroom");
+        @Test
+        void computeIfAbsentShouldReturnValueAndNotModifyMapWhenValueIsPresent() {
+            var entries = Map.of("Link", "Master Sword");
+            var map = new HashMap<>(entries);
 
-        assertThat(result)
-                .isEqualTo("Super Mushroom");
+            var result = computeIfAbsent(map, "Link", () -> fail("Should not have executed compute function"));
 
-        assertThat(map)
-                .hasSize(2)
-                .containsAllEntriesOf(entries)
-                .containsEntry("Mario", "Super Mushroom");
-    }
+            assertThat(result)
+                    .isEqualTo("Master Sword");
 
-    @Test
-    void computeIfAbsentShouldReturnNullAndNotModifyMapWhenComputeReturnsNull() {
-        var entries = Map.of("Link", "Master Sword");
-        var map = new HashMap<>(entries);
+            assertThat(map)
+                    .containsExactlyEntriesOf(entries);
+        }
 
-        var result = computeIfAbsent(map, "Mario", x -> null);
+        @Test
+        void computeIfAbsentShouldComputeAndReturnValueAndModifyMapWhenValueIsNotPresent() {
+            var entries = Map.of("Link", "Master Sword");
+            var map = new HashMap<>(entries);
 
-        assertThat(result)
-                .isNull();
+            var result = computeIfAbsent(map, "Mario", () -> "Super Mushroom");
 
-        assertThat(map)
-                .containsExactlyEntriesOf(entries);
-    }
+            assertThat(result)
+                    .isEqualTo("Super Mushroom");
 
-    @Test
-    void computeIfAbsentShouldBubbleUpExceptionAndNotModifyMapWhenComputeThrows() {
-        var entries = Map.of("Link", "Master Sword");
-        var map = new HashMap<>(entries);
-        var exception = new Exception("Mock exception");
+            assertThat(map)
+                    .hasSize(2)
+                    .containsAllEntriesOf(entries)
+                    .containsEntry("Mario", "Super Mushroom");
+        }
 
-        assertThatException()
-                .isThrownBy(() -> computeIfAbsent(map, "Mario", x -> {throw exception;}))
-                .isEqualTo(exception);
+        @Test
+        void computeIfAbsentShouldReturnNullAndNotModifyMapWhenComputeReturnsNull() {
+            var entries = Map.of("Link", "Master Sword");
+            var map = new HashMap<>(entries);
 
-        assertThat(map)
-                .containsExactlyEntriesOf(entries);
+            var result = computeIfAbsent(map, "Mario", () -> null);
+
+            assertThat(result)
+                    .isNull();
+
+            assertThat(map)
+                    .containsExactlyEntriesOf(entries);
+        }
+
+        @Test
+        void computeIfAbsentShouldBubbleUpExceptionAndNotModifyMapWhenComputeThrows() {
+            var entries = Map.of("Link", "Master Sword");
+            var map = new HashMap<>(entries);
+            var exception = new Exception("Mock exception");
+
+            assertThatException()
+                    .isThrownBy(() -> computeIfAbsent(map, "Mario", () -> {throw exception;}))
+                    .isEqualTo(exception);
+
+            assertThat(map)
+                    .containsExactlyEntriesOf(entries);
+        }
+
     }
 
 

--- a/src/test/java/io/blt/util/CtrTest.java
+++ b/src/test/java/io/blt/util/CtrTest.java
@@ -37,11 +37,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static io.blt.test.AssertUtils.assertValidUtilityClass;
+import static io.blt.util.Ctr.computeIfAbsent;
 import static io.blt.util.Ctr.transformValues;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class CtrTest {
 
@@ -79,7 +81,7 @@ class CtrTest {
     @ParameterizedTest
     @MethodSource
     void transformValuesShouldReturnEmptyMapOfSameType(Map<String, Month> map) {
-        var result = transformValues(map, e -> { throw new IllegalStateException(); });
+        var result = transformValues(map, e -> {throw new IllegalStateException();});
 
         assertThat(result)
                 .hasSameClassAs(map)
@@ -97,8 +99,67 @@ class CtrTest {
         var exception = new Exception();
 
         assertThatException()
-                .isThrownBy(() -> transformValues(Map.of("hello", "Worf"), e -> { throw exception; }))
+                .isThrownBy(() -> transformValues(Map.of("hello", "Worf"), e -> {throw exception;}))
                 .isEqualTo(exception);
     }
+
+    @Test
+    void computeIfAbsentShouldReturnValueAndNotModifyMapWhenValueIsPresent() {
+        var entries = Map.of("Link", "Master Sword");
+        var map = new HashMap<>(entries);
+
+        var result = computeIfAbsent(map, "Link", x -> fail("Should not have executed compute function"));
+
+        assertThat(result)
+                .isEqualTo("Master Sword");
+
+        assertThat(map)
+                .containsExactlyEntriesOf(entries);
+    }
+
+    @Test
+    void computeIfAbsentShouldComputeAndReturnValueAndModifyMapWhenValueIsNotPresent() {
+        var entries = Map.of("Link", "Master Sword");
+        var map = new HashMap<>(entries);
+
+        var result = computeIfAbsent(map, "Mario", x -> "Super Mushroom");
+
+        assertThat(result)
+                .isEqualTo("Super Mushroom");
+
+        assertThat(map)
+                .hasSize(2)
+                .containsAllEntriesOf(entries)
+                .containsEntry("Mario", "Super Mushroom");
+    }
+
+    @Test
+    void computeIfAbsentShouldReturnNullAndNotModifyMapWhenComputeReturnsNull() {
+        var entries = Map.of("Link", "Master Sword");
+        var map = new HashMap<>(entries);
+
+        var result = computeIfAbsent(map, "Mario", x -> null);
+
+        assertThat(result)
+                .isNull();
+
+        assertThat(map)
+                .containsExactlyEntriesOf(entries);
+    }
+
+    @Test
+    void computeIfAbsentShouldBubbleUpExceptionAndNotModifyMapWhenComputeThrows() {
+        var entries = Map.of("Link", "Master Sword");
+        var map = new HashMap<>(entries);
+        var exception = new Exception("Mock exception");
+
+        assertThatException()
+                .isThrownBy(() -> computeIfAbsent(map, "Mario", x -> {throw exception;}))
+                .isEqualTo(exception);
+
+        assertThat(map)
+                .containsExactlyEntriesOf(entries);
+    }
+
 
 }


### PR DESCRIPTION
Computes a value for a `Map` if one is not currently present and returns the value.

This is basically the same as `map.computeIfAbsent(...)` but supports `ThrowingFunction` and `ThrowingSupplier`.

```java
private final Map<URL, String> cache = new HashMap<>();

public String fetch(URL url) throws IOException {
    return Ctr.computeIfAbsent(cache, url, () -> {
        try (var stream = url.openStream()) {
            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
        }
    });
}
```