### PR TITLE
Feature/transform exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ e.g., to add the core library to your dependencies:
 ### `Obj`
 
 > Static utility methods for operating on `Object`
+> 
+> Includes object construction, mutation, fallbacks and validation
 
 #### `tap` and `poke`
 
@@ -127,6 +129,32 @@ This is very similar to `map.computeIfAbsent(...)` but supports both functions a
 public String fetch(URL url) throws IOException {
     return Ctr.computeIfAbsent(cache, url, () ->
             IOUtils.toString(url, StandardCharsets.UTF_8));
+}
+```
+
+### `Ex`
+
+> Static utility methods centred around `Exception` and `Throwable`
+> 
+> Includes raising and handling exceptions
+
+#### `transformExceptions`
+
+Executes a function, transforming any thrown exception.
+
+This can be useful when a method or lambda throws many checked exception types which should be mapped to a higher-level
+exception.
+
+e.g. say we have a custom `XmlProcessingException` that we want to raise for any exception related to parsing XML:
+
+```java
+public Document parseXml(String pathname) throws XmlProcessingException {
+    return transformExceptions(
+            () -> DocumentBuilderFactory
+                    .newInstance()
+                    .newDocumentBuilder()       // throws ParserConfigurationException
+                    .parse(new File(pathname)), // throws SAXException, IOException
+            XmlProcessingException::new);
 }
 ```
 

--- a/src/main/java/io/blt/util/Ex.java
+++ b/src/main/java/io/blt/util/Ex.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2024 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util;
+
+import io.blt.util.functional.ThrowingRunnable;
+import io.blt.util.functional.ThrowingSupplier;
+import java.util.function.Function;
+
+/**
+ * Static utility methods centred around {@code Exception} and {@code Throwable}.
+ * <p>Includes raising and handling exceptions.</p>
+ */
+public final class Ex {
+
+    private Ex() {
+        throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
+    }
+
+    /**
+     * Executes a supplier, transforming any thrown exception using a specified function.
+     *
+     * @param <R>         The result type of the supplier
+     * @param <E>         The type of transformed exception
+     * @param supplier    The supplier that may throw an exception
+     * @param transformer Function to transform exceptions thrown by the supplier
+     * @return The result of the supplier if successful
+     * @throws E If the supplier throws an exception, transformed by the provided function
+     */
+    public static <R, E extends Throwable> R transformExceptions(
+            ThrowingSupplier<R, ? extends Exception> supplier, Function<? super Exception, E> transformer) throws E {
+        try {
+            return supplier.get();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw transformer.apply(e);
+        }
+    }
+
+    /**
+     * Executes a runnable, transforming any thrown exception using a specified function
+     *
+     * @param <E>         The type of transformed exception
+     * @param runnable    The runnable that may throw an exception
+     * @param transformer Function to transform exceptions thrown by the supplier
+     * @throws E If the supplier throws an exception, transformed by the provided function
+     */
+    public static <E extends Throwable> void transformExceptions(
+            ThrowingRunnable<? extends Exception> runnable, Function<? super Exception, E> transformer) throws E {
+        transformExceptions(() -> {
+            runnable.run();
+            return null;
+        }, transformer);
+    }
+
+}

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -35,6 +35,8 @@ import static java.util.Objects.nonNull;
 
 /**
  * Static utility methods for operating on {@code Object}.
+ *
+ * <p>Includes object construction, mutation, fallbacks and validation.</p>
  */
 public final class Obj {
 

--- a/src/main/java/io/blt/util/functional/ThrowingFunction.java
+++ b/src/main/java/io/blt/util/functional/ThrowingFunction.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Michael Cowan
+ * Copyright (c) 2023-2024 Michael Cowan
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,10 +26,12 @@ package io.blt.util.functional;
 
 /**
  * Represents a function that may throw and accepts one argument and produces a result.
+ * <p>Like {@code Function} but able to throw an exception</p>
  *
  * @param <T> the type of argument consumed by this function
  * @param <R> the type of results returned by this function
  * @param <E> the type of {@code Throwable} that may be thrown by this function
+ * @see java.util.function.Function
  */
 @FunctionalInterface
 public interface ThrowingFunction<T, R, E extends Throwable> {
@@ -40,6 +42,7 @@ public interface ThrowingFunction<T, R, E extends Throwable> {
      * @param t the function argument
      * @return the function result
      * @throws E {@code Throwable} that may be thrown
+     * @see java.util.function.Function#apply(Object)
      */
     R apply(T t) throws E;
 

--- a/src/main/java/io/blt/util/functional/ThrowingRunnable.java
+++ b/src/main/java/io/blt/util/functional/ThrowingRunnable.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2024 Michael Cowan
+ * Copyright (c) 2024 Michael Cowan
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,23 +25,21 @@
 package io.blt.util.functional;
 
 /**
- * Represents an operation that accepts a single input argument that may throw.
- * <p>Like {@code Consumer} but able to throw an exception</p>
+ * Represents an operation that may throw.
+ * <p>Like {@code Runnable} but able to throw an exception</p>
  *
- * @param <T> the type of argument consumed by this consumer
- * @param <E> the type of {@code Throwable} that may be thrown by this consumer
- * @see java.util.function.Consumer
+ * @param <E> the type of {@code Throwable} that may be thrown by this runnable
+ * @see java.lang.Runnable
  */
 @FunctionalInterface
-public interface ThrowingConsumer<T, E extends Throwable> {
+public interface ThrowingRunnable<E extends Throwable> {
 
     /**
-     * Performs this operation on the given argument.
+     * Performs this operation.
      *
-     * @param t the input argument
      * @throws E {@code Throwable} that may be thrown
-     * @see java.util.function.Consumer#accept(Object)
+     * @see Runnable#run()
      */
-    void accept(T t) throws E;
+    void run() throws E;
 
 }

--- a/src/main/java/io/blt/util/functional/ThrowingSupplier.java
+++ b/src/main/java/io/blt/util/functional/ThrowingSupplier.java
@@ -28,9 +28,11 @@ import io.blt.util.Obj;
 
 /**
  * Represents a supplier of results that may throw.
+ * <p>Like {@code Supplier} but able to throw an exception</p>
  *
  * @param <T> the type of results supplied by this supplier
  * @param <E> the type of {@code Throwable} that may be thrown by this supplier
+ * @see java.util.function.Supplier
  */
 @FunctionalInterface
 public interface ThrowingSupplier<T, E extends Throwable> {
@@ -40,6 +42,7 @@ public interface ThrowingSupplier<T, E extends Throwable> {
      *
      * @return a result
      * @throws E {@code Throwable} that may be thrown
+     * @see java.util.function.Supplier#get()
      */
     T get() throws E;
 

--- a/src/test/java/io/blt/util/ExTest.java
+++ b/src/test/java/io/blt/util/ExTest.java
@@ -1,0 +1,122 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2024 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util;
+
+import io.blt.util.functional.ThrowingRunnable;
+import io.blt.util.functional.ThrowingSupplier;
+import java.io.IOException;
+import java.util.function.Function;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.blt.test.AssertUtils.assertValidUtilityClass;
+import static io.blt.util.Ex.transformExceptions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Fail.fail;
+
+class ExTest {
+
+    IOException mockException = new IOException("mock exception");
+
+    @Test
+    void shouldBeValidUtilityClass() throws NoSuchMethodException {
+        assertValidUtilityClass(Ex.class);
+    }
+
+    @Nested
+    class UsingThrowingSupplier {
+
+        ThrowingSupplier<String, IOException> supplier = () -> "hello Worf";
+
+        ThrowingSupplier<String, IOException> throwingSupplier = () -> {
+            throw mockException;
+        };
+
+        @Test
+        void transformExceptionsShouldReturnResultWhenNoExceptionIsThrown() throws Throwable {
+            var result = transformExceptions(supplier, r ->
+                    fail("Should not have executed transformer function"));
+
+            assertThat(result)
+                    .isEqualTo("hello Worf");
+        }
+
+        @Test
+        void transformExceptionsShouldCallAndThrowTransformerWhenExceptionIsThrown() {
+            var expected = new Exception("transformed exception");
+
+            var transformer = new Function<Exception, Throwable>() {
+                @Override
+                public Throwable apply(Exception e) {
+                    assertThat(e).isEqualTo(mockException);
+                    return expected;
+                }
+            };
+
+            assertThatException()
+                    .isThrownBy(() -> transformExceptions(throwingSupplier, transformer))
+                    .isEqualTo(expected);
+        }
+
+    }
+
+    @Nested
+    class UsingThrowingRunnable {
+
+        ThrowingRunnable<IOException> runnable = () -> {};
+
+        ThrowingRunnable<IOException> throwingRunnable = () -> {
+            throw mockException;
+        };
+
+        @Test
+        void transformExceptionsShouldNotThrowWhenNoExceptionIsThrown() {
+            assertThatNoException()
+                    .isThrownBy(() -> transformExceptions(runnable, r ->
+                            fail("Should not have executed transformer function")));
+        }
+
+        @Test
+        void transformExceptionsShouldCallAndThrowTransformerWhenExceptionIsThrown() {
+            var expected = new Exception("transformed exception");
+
+            var transformer = new Function<Exception, Throwable>() {
+                @Override
+                public Throwable apply(Exception e) {
+                    assertThat(e).isEqualTo(mockException);
+                    return expected;
+                }
+            };
+
+            assertThatException()
+                    .isThrownBy(() -> transformExceptions(throwingRunnable, transformer))
+                    .isEqualTo(expected);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Executes a function, transforming any thrown exception.

This can be useful when a method or lambda throws many checked exception types which should be mapped to a higher-level
exception.

e.g. say we have a custom `XmlProcessingException` that we want to raise for any exception related to parsing XML:

```java
public Document parseXml(String pathname) throws XmlProcessingException {
    return transformExceptions(
            () -> DocumentBuilderFactory
                    .newInstance()
                    .newDocumentBuilder()       // throws ParserConfigurationException
                    .parse(new File(pathname)), // throws SAXException, IOException
            XmlProcessingException::new);
}
```