### PR TITLE
Move throwIf and throwUnless from Obj to Ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,6 @@ private InputStream openFileOrResource(String name) {
 }
 ```
 
-#### `throwIf` and `throwUnless`
-
-Throws a provided exception if the given `value` satisfies (or doesn't satisfy) the provided `predicate`.
-e.g.,
-
-```java
-public Map<String, String> loadProperties() {
-    return Obj.throwIf(Properties.loadFromJson(FILENAME), Map::isEmpty,
-            () -> new IllegalStateException("Properties must not be empty"));
-}
-```
-
 #### `newInstanceOf`
 
 Creates a new instance of the same type as the input object if possible, otherwise, returns empty. e.g.,
@@ -159,6 +147,18 @@ public Document parseXml(String pathname) throws XmlProcessingException {
                     .newDocumentBuilder()       // throws ParserConfigurationException
                     .parse(new File(pathname)), // throws SAXException, IOException
             XmlProcessingException::new);
+}
+```
+
+#### `throwIf` and `throwUnless`
+
+Throws a provided exception if the given `value` satisfies (or doesn't satisfy) the provided `predicate`.
+e.g.,
+
+```java
+public Map<String, String> loadProperties() {
+    return Ex.throwIf(Properties.loadFromJson(FILENAME), Map::isEmpty,
+            () -> new IllegalStateException("Properties must not be empty"));
 }
 ```
 

--- a/src/main/java/io/blt/util/Ex.java
+++ b/src/main/java/io/blt/util/Ex.java
@@ -27,6 +27,8 @@ package io.blt.util;
 import io.blt.util.functional.ThrowingRunnable;
 import io.blt.util.functional.ThrowingSupplier;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Static utility methods centred around {@code Exception} and {@code Throwable}.
@@ -105,6 +107,57 @@ public final class Ex {
             runnable.run();
             return null;
         }, transformer);
+    }
+
+    /**
+     * Throws the specified {@code throwable} if the given {@code value} satisfies the provided {@code predicate}.
+     * For convenience, {@code value} is returned.
+     * e.g.,
+     * <pre>{@code
+     * public Map<String, String> loadProperties() {
+     *     return throwIf(Properties.loadFromJson(FILENAME), Map::isEmpty,
+     *             () -> new IllegalStateException("Properties must not be empty"));
+     * }
+     * }</pre>
+     *
+     * @param value     the value to be checked
+     * @param predicate the predicate to be evaluated
+     * @param throwable the supplier for the throwable to be thrown
+     * @param <T>       the type of the value
+     * @param <E>       the type of the throwable
+     * @return {@code value}
+     * @throws E if the given {@code value} satisfies the provided {@code predicate}
+     * @see Ex#throwUnless(Object, Predicate, Supplier)
+     */
+    public static <T, E extends Throwable> T throwIf(
+            T value, Predicate<? super T> predicate, Supplier<? extends E> throwable) throws E {
+        if (predicate.test(value)) {
+            throw throwable.get();
+        }
+        return value;
+    }
+
+    /**
+     * Throws the specified {@code throwable} if the given {@code value} does not satisfy the provided {@code predicate}.
+     * For convenience, {@code value} is returned.
+     * e.g.,
+     * <pre>{@code
+     * throwUnless(properties, p -> p.containsKey("host"),
+     *         () -> new IllegalStateException("Properties must contain a host"));
+     * }</pre>
+     *
+     * @param value     the value to be checked
+     * @param predicate the predicate to be evaluated
+     * @param throwable the supplier for the throwable to be thrown
+     * @param <T>       the type of the value
+     * @param <E>       the type of the throwable
+     * @return {@code value}
+     * @throws E if the given {@code value} does not satisfy the provided {@code predicate}
+     * @see Ex#throwIf(Object, Predicate, Supplier)
+     */
+    public static <T, E extends Throwable> T throwUnless(
+            T value, Predicate<? super T> predicate, Supplier<? extends E> throwable) throws E {
+        return throwIf(value, predicate.negate(), throwable);
     }
 
 }

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -140,54 +140,25 @@ public final class Obj {
     }
 
     /**
-     * Throws the specified {@code throwable} if the given {@code value} satisfies the provided {@code predicate}.
-     * For convenience, {@code value} is returned.
-     * e.g.,
-     * <pre>{@code
-     * public Map<String, String> loadProperties() {
-     *     return throwIf(Properties.loadFromJson(FILENAME), Map::isEmpty,
-     *             () -> new IllegalStateException("Properties must not be empty"));
-     * }
-     * }</pre>
-     *
-     * @param value     the value to be checked
-     * @param predicate the predicate to be evaluated
-     * @param throwable the supplier for the throwable to be thrown
-     * @param <T>       the type of the value
-     * @param <E>       the type of the throwable
-     * @return {@code value}
-     * @throws E if the given {@code value} satisfies the provided {@code predicate}
-     * @see Obj#throwUnless(Object, Predicate, Supplier)
+     * @deprecated
+     * This has been moved to {@link Ex}.
+     * <p>Use {@link Ex#throwIf(Object, Predicate, Supplier)} instead.</p>
      */
+    @Deprecated(since = "1.0.7", forRemoval = true)
     public static <T, E extends Throwable> T throwIf(
             T value, Predicate<? super T> predicate, Supplier<? extends E> throwable) throws E {
-        if (predicate.test(value)) {
-            throw throwable.get();
-        }
-        return value;
+        return Ex.throwIf(value, predicate, throwable);
     }
 
     /**
-     * Throws the specified {@code throwable} if the given {@code value} does not satisfy the provided {@code predicate}.
-     * For convenience, {@code value} is returned.
-     * e.g.,
-     * <pre>{@code
-     * throwUnless(properties, p -> p.containsKey("host"),
-     *         () -> new IllegalStateException("Properties must contain a host"));
-     * }</pre>
-     *
-     * @param value     the value to be checked
-     * @param predicate the predicate to be evaluated
-     * @param throwable the supplier for the throwable to be thrown
-     * @param <T>       the type of the value
-     * @param <E>       the type of the throwable
-     * @return {@code value}
-     * @throws E if the given {@code value} does not satisfy the provided {@code predicate}
-     * @see Obj#throwIf(Object, Predicate, Supplier)
+     * @deprecated
+     * This has been moved to {@link Ex}.
+     * <p>Use {@link Ex#throwUnless(Object, Predicate, Supplier)} instead.</p>
      */
+    @Deprecated(since = "1.0.7", forRemoval = true)
     public static <T, E extends Throwable> T throwUnless(
             T value, Predicate<? super T> predicate, Supplier<? extends E> throwable) throws E {
-        return throwIf(value, predicate.negate(), throwable);
+        return Ex.throwUnless(value, predicate, throwable);
     }
 
     /**

--- a/src/test/java/io/blt/util/ExTest.java
+++ b/src/test/java/io/blt/util/ExTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.blt.test.AssertUtils.assertValidUtilityClass;
+import static io.blt.util.Ex.throwIf;
+import static io.blt.util.Ex.throwUnless;
 import static io.blt.util.Ex.transformExceptions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
@@ -144,6 +146,44 @@ class ExTest {
                     .isEqualTo(mockUncheckedException);
         }
 
+    }
+
+    @Test
+    void throwIfShouldThrowWhenPredicateIsTrue() {
+        var exception = new Exception("mock exception");
+
+        assertThatException()
+                .isThrownBy(() -> throwIf(null, v -> true, () -> exception))
+                .isEqualTo(exception);
+    }
+
+    @Test
+    void throwIfShouldReturnValueWhenPredicateIsFalse() throws Exception {
+        var value = "mock value";
+
+        var result = throwIf(value, v -> false, () -> new Exception("mock exception"));
+
+        assertThat(result)
+                .isEqualTo(value);
+    }
+
+    @Test
+    void throwUnlessShouldThrowWhenPredicateIsFalse() {
+        var exception = new Exception("mock exception");
+
+        assertThatException()
+                .isThrownBy(() -> throwUnless(null, v -> false, () -> exception))
+                .isEqualTo(exception);
+    }
+
+    @Test
+    void throwUnlessShouldReturnValueWhenPredicateIsTrue() throws Exception {
+        var value = "mock value";
+
+        var result = throwUnless(value, v -> true, () -> new Exception("mock exception"));
+
+        assertThat(result)
+                .isEqualTo(value);
     }
 
 }

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -44,8 +44,6 @@ import static io.blt.util.Obj.orElseGet;
 import static io.blt.util.Obj.orElseOnException;
 import static io.blt.util.Obj.poke;
 import static io.blt.util.Obj.tap;
-import static io.blt.util.Obj.throwIf;
-import static io.blt.util.Obj.throwUnless;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -194,44 +192,6 @@ class ObjTest {
         var result = orElseOnException(() -> {throw new Exception("mock exception");}, value);
 
         assertThat(result).isEqualTo(value);
-    }
-
-    @Test
-    void throwIfShouldThrowWhenPredicateIsTrue() {
-        var exception = new Exception("mock exception");
-
-        assertThatException()
-                .isThrownBy(() -> throwIf(null, v -> true, () -> exception))
-                .isEqualTo(exception);
-    }
-
-    @Test
-    void throwIfShouldReturnValueWhenPredicateIsFalse() throws Exception {
-        var value = "mock value";
-
-        var result = throwIf(value, v -> false, () -> new Exception("mock exception"));
-
-        assertThat(result)
-                .isEqualTo(value);
-    }
-
-    @Test
-    void throwUnlessShouldThrowWhenPredicateIsFalse() {
-        var exception = new Exception("mock exception");
-
-        assertThatException()
-                .isThrownBy(() -> throwUnless(null, v -> false, () -> exception))
-                .isEqualTo(exception);
-    }
-
-    @Test
-    void throwUnlessShouldReturnValueWhenPredicateIsTrue() throws Exception {
-        var value = "mock value";
-
-        var result = throwUnless(value, v -> true, () -> new Exception("mock exception"));
-
-        assertThat(result)
-                .isEqualTo(value);
     }
 
     static Stream<Arguments> newInstanceOfShouldReturnNewInstanceOf() {


### PR DESCRIPTION
Move `throwIf` and `throwUnless` from `Obj` to `Ex`.

`Obj` just seems the wrong place for these since adding the `Ex` class (https://github.com/michaelcowan/blt-core/pull/32).

