### PR TITLE
Add orEmptyOnException to Obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ private InputStream openFileOrResource(String name) {
 }
 ```
 
+#### `orEmptyOnException`
+
+Invokes and returns the result of a supplier wrapped in an `Optional`, unless the supplier throws, in which case empty 
+is returned.
+
+e.g.,
+
+```java
+private Optional<HttpResponse<InputStream>> fetchAsStream(HttpRequest request) {
+    try (var client = HttpClient.newHttpClient()) {
+        return Obj.orEmptyOnException(() -> client.send(
+                request, HttpResponse.BodyHandlers.ofInputStream()));
+    }
+}
+```
+
 #### `newInstanceOf`
 
 Creates a new instance of the same type as the input object if possible, otherwise, returns empty. e.g.,

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -162,6 +162,27 @@ public final class Obj {
     }
 
     /**
+     * Invokes and returns the result of {@code supplier} if no exception is thrown; otherwise, returns empty.
+     * e.g.,
+     * <pre>{@code
+     * private Optional<HttpResponse<InputStream>> fetchAsStream(HttpRequest request) {
+     *     try (var client = HttpClient.newHttpClient()) {
+     *         return Obj.orEmptyOnException(() -> client.send(
+     *                 request, HttpResponse.BodyHandlers.ofInputStream()));
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param supplier called and returned as an {@link Optional} if no exception is thrown
+     * @param <T>      type of the returned value
+     * @param <E>      type of {@code supplier} throwable
+     * @return result of {@code supplier} as an {@link Optional} if no exception is thrown, else empty
+     */
+    public static <T, E extends Throwable> Optional<T> orEmptyOnException(ThrowingSupplier<T, E> supplier) {
+        return Optional.ofNullable(orElseOnException(supplier, null));
+    }
+
+    /**
      * Returns a new instance of the same type as the input object if possible; otherwise, returns empty.
      * Supports only instances of concrete types that have a public zero argument constructor.
      * e.g.,

--- a/src/test/java/io/blt/util/ObjTest.java
+++ b/src/test/java/io/blt/util/ObjTest.java
@@ -42,6 +42,7 @@ import static io.blt.test.AssertUtils.assertValidUtilityClass;
 import static io.blt.util.Obj.newInstanceOf;
 import static io.blt.util.Obj.orElseGet;
 import static io.blt.util.Obj.orElseOnException;
+import static io.blt.util.Obj.orEmptyOnException;
 import static io.blt.util.Obj.poke;
 import static io.blt.util.Obj.tap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +63,8 @@ class ObjTest {
         void pokeShouldReturnInstance() {
             var instance = new Object();
 
-            var result = poke(instance, c -> {});
+            var result = poke(instance, c -> {
+            });
 
             assertThat(result).isEqualTo(instance);
         }
@@ -95,7 +97,9 @@ class ObjTest {
             var exception = new IOException("mock checked exception");
 
             assertThatException()
-                    .isThrownBy(() -> poke(new User(), u -> {throw exception;}))
+                    .isThrownBy(() -> poke(new User(), u -> {
+                        throw exception;
+                    }))
                     .isEqualTo(exception);
         }
 
@@ -108,9 +112,11 @@ class ObjTest {
         void tapShouldReturnSuppliedInstance() {
             var instance = new Object();
 
-            var result = tap(() -> instance, s -> {});
+            var result = tap(() -> instance, s -> {
+            });
 
-            result = tap(() -> instance, s -> {});
+            result = tap(() -> instance, s -> {
+            });
 
             assertThat(result).isEqualTo(instance);
         }
@@ -143,7 +149,9 @@ class ObjTest {
             var exception = new IOException("mock checked exception");
 
             assertThatException()
-                    .isThrownBy(() -> tap(User::new, u -> {throw exception;}))
+                    .isThrownBy(() -> tap(User::new, u -> {
+                        throw exception;
+                    }))
                     .isEqualTo(exception);
         }
 
@@ -172,7 +180,9 @@ class ObjTest {
         var exception = new Exception("mock exception");
 
         assertThatException()
-                .isThrownBy(() -> orElseGet(null, () -> {throw exception;}))
+                .isThrownBy(() -> orElseGet(null, () -> {
+                    throw exception;
+                }))
                 .isEqualTo(exception);
     }
 
@@ -189,9 +199,29 @@ class ObjTest {
     void orElseOnExceptionShouldReturnValueIfExceptionIsThrown() {
         var value = "Sven";
 
-        var result = orElseOnException(() -> {throw new Exception("mock exception");}, value);
+        var result = orElseOnException(() -> {
+            throw new Exception("mock exception");
+        }, value);
 
         assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    void orEmptyOnExceptionShouldReturnSupplierResultIfNoExceptionIsThrown() {
+        var supplierResult = "Greg";
+
+        var result = orEmptyOnException(() -> supplierResult);
+
+        assertThat(result).contains(supplierResult);
+    }
+
+    @Test
+    void orEmptyOnExceptionShouldReturnEmptyIfExceptionIsThrown() {
+        var result = orEmptyOnException(() -> {
+            throw new Exception("mock exception");
+        });
+
+        assertThat(result).isEmpty();
     }
 
     static Stream<Arguments> newInstanceOfShouldReturnNewInstanceOf() {


### PR DESCRIPTION
Invokes a supplier and returns the result as an `Optional`, unless the supplier throws in which case returns empty.

This allows invoking `Optional` semantics as a response to thrown exceptions.