### PR TITLE
Add of and ofIgnoreCase to En

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,29 @@ public Map<String, String> loadProperties() {
 }
 ```
 
+### `En`
+
+> Static utility methods for operating on `Enum`
+
+#### `of` and `ofIgnoreCase`
+
+Returns the `enum` constant matching `name` as an `Optional`; otherwise, returns empty.
+e.g.,
+
+```java
+of(DayOfWeek.class, "FRIDAY");    // Optional.of(DayOfWeek.FRIDAY)
+of(DayOfWeek.class, "friday");    // Optional.empty()
+of(DayOfWeek.class, "Worf");      // Optional.empty()
+of(DayOfWeek.class, "");          // Optional.empty()
+```
+
+Or, ignoring case:
+
+```java
+ofIgnoreCase(DayOfWeek.class, "FRIDAY");    // Optional.of(DayOfWeek.FRIDAY)
+ofIgnoreCase(DayOfWeek.class, "friday");    // Optional.of(DayOfWeek.FRIDAY)
+```
+
 ### `SingletonCollectors`
 
 Implementations of `Collector` that reduce to exactly one or zero elements.

--- a/src/main/java/io/blt/util/En.java
+++ b/src/main/java/io/blt/util/En.java
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util;
+
+import java.util.Optional;
+
+/**
+ * Static utility methods for operating on {@code Enum}.
+ */
+public final class En {
+
+    private En() {
+        throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
+    }
+
+    /**
+     * Returns the {@code enum} constant matching {@code name} as an {@link Optional}; otherwise, returns empty.
+     * The {@code name} must match exactly.
+     * <p>
+     * This method will not throw for an invalid enum name and instead will return empty.
+     * </p>
+     * e.g.,
+     * <pre>{@code
+     * of(DayOfWeek.class, "FRIDAY");    // Optional.of(DayOfWeek.FRIDAY)
+     * of(DayOfWeek.class, "friday");    // Optional.empty()
+     * of(DayOfWeek.class, "Worf");      // Optional.empty()
+     * of(DayOfWeek.class, "");          // Optional.empty()
+     * }</pre>
+     *
+     * @param type The {@link Class} object of the enum class
+     * @param name The name of the constant to return
+     * @param <E>  The type of the {@code Enum}
+     * @return an {@code Optional} containing the {@code enum} constant if found
+     * @throws NullPointerException if {@code type} or {@code name} is {@code null}
+     */
+    public static <E extends Enum<E>> Optional<E> of(Class<E> type, String name) {
+        try {
+            return Optional.of(Enum.valueOf(type, name));
+        } catch (IllegalArgumentException ignore) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns the {@code enum} constant matching {@code name} as an {@link Optional}; otherwise, returns empty.
+     * The {@code name} comparison is case-insensitive.
+     * <p>
+     * This method will not throw for an invalid enum name and instead will return empty.
+     * </p>
+     * <pre>{@code
+     * ofIgnoreCase(DayOfWeek.class, "FRIDAY");    // Optional.of(DayOfWeek.FRIDAY)
+     * ofIgnoreCase(DayOfWeek.class, "friday");    // Optional.of(DayOfWeek.FRIDAY)
+     * ofIgnoreCase(DayOfWeek.class, "Worf");      // Optional.empty()
+     * ofIgnoreCase(DayOfWeek.class, "");          // Optional.empty()
+     * }</pre>
+     *
+     * @param type The {@link Class} object of the enum class
+     * @param name The name of the constant to return
+     * @param <E>  The type of the {@code Enum}
+     * @return an {@code Optional} containing the {@code enum} constant if found
+     * @throws NullPointerException if {@code type} or {@code name} is {@code null}
+     */
+    public static <E extends Enum<E>> Optional<E> ofIgnoreCase(Class<E> type, String name) {
+        for (var element : type.getEnumConstants()) {
+            if (name.equalsIgnoreCase(element.name())) {
+                return Optional.of(element);
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/io/blt/util/Obj.java
+++ b/src/main/java/io/blt/util/Obj.java
@@ -61,7 +61,7 @@ public final class Obj {
      * @param consumer operation to perform on {@code instance}
      * @param <T>      type of {@code instance}
      * @param <E>      type of {@code consumer} throwable
-     * @return {@code instance} after accepting side effects via {@code consumer}.
+     * @return {@code instance} after accepting side effects via {@code consumer}
      */
     public static <T, E extends Throwable> T poke(T instance, ThrowingConsumer<T, E> consumer) throws E {
         consumer.accept(instance);
@@ -85,7 +85,7 @@ public final class Obj {
      * @param consumer operation to perform on supplied instance
      * @param <T>      type of instance
      * @param <E>      type of {@code consumer} throwable
-     * @return Supplied instance after applying side effects via {@code consumer}.
+     * @return Supplied instance after applying side effects via {@code consumer}
      */
     public static <T, E extends Throwable> T tap(Supplier<T> supplier, ThrowingConsumer<T, E> consumer) throws E {
         return poke(supplier.get(), consumer);
@@ -134,7 +134,7 @@ public final class Obj {
     public static <T, E extends Throwable> T orElseOnException(ThrowingSupplier<T, E> supplier, T defaultValue) {
         try {
             return supplier.get();
-        } catch (Throwable e) {
+        } catch (Throwable ignore) {
             return defaultValue;
         }
     }
@@ -203,7 +203,7 @@ public final class Obj {
         } catch (InstantiationException
                  | IllegalAccessException
                  | InvocationTargetException
-                 | NoSuchMethodException e) {
+                 | NoSuchMethodException ignore) {
             return Optional.empty();
         }
     }

--- a/src/test/java/io/blt/util/EnTest.java
+++ b/src/test/java/io/blt/util/EnTest.java
@@ -1,0 +1,193 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Michael Cowan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.blt.util;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static io.blt.test.AssertUtils.assertValidUtilityClass;
+import static io.blt.util.En.of;
+import static io.blt.util.En.ofIgnoreCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class EnTest <E extends Enum<E>> {
+
+    @Test
+    void shouldBeValidUtilityClass() throws NoSuchMethodException {
+        assertValidUtilityClass(Obj.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("names")
+    void ofShouldReturnExpectedEnumWhenValueIsEnumName(Class<E> type, E expected, String value) {
+        var result = of(type, value);
+
+        assertThat(result)
+                .isEqualTo(Optional.of(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("lowerCaseNames")
+    void ofShouldReturnEmptyWhenValueIsChangedCaseEnumName(Class<E> type, E unused, String value) {
+        var result = of(type, value);
+
+        assertThat(result)
+                .isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalid")
+    void ofShouldReturnEmptyWhenValueIs(String value) {
+        var result = of(SimpleEnum.class, value);
+
+        assertThat(result)
+                .isEmpty();
+    }
+
+    @Test
+    void ofShouldThrowWhenValueIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> of(SimpleEnum.class, null));
+    }
+
+    @Test
+    void ofShouldThrowWhenTypeIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> of(null, "value"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("names")
+    void ofIgnoreCaseShouldReturnExpectedEnumWhenValueIsEnumName(Class<E> type, E expected, String value) {
+        var result = ofIgnoreCase(type, value);
+
+        assertThat(result)
+                .isEqualTo(Optional.of(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("lowerCaseNames")
+    void ofIgnoreCaseShouldReturnExpectedEnumWhenValueIsChangedCaseEnumName(Class<E> type, E expected, String value) {
+        var result = ofIgnoreCase(type, value);
+
+        assertThat(result)
+                .isEqualTo(Optional.of(expected));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalid")
+    void ofIgnoreCaseShouldReturnEmptyWhenValueIs(String value) {
+        var result = ofIgnoreCase(SimpleEnum.class, value);
+
+        assertThat(result)
+                .isEmpty();
+    }
+
+    @Test
+    void ofIgnoreCaseShouldThrowWhenValueIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> ofIgnoreCase(SimpleEnum.class, null));
+    }
+
+    @Test
+    void ofIgnoreCaseShouldThrowWhenTypeIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> ofIgnoreCase(null, "value"));
+    }
+
+    enum SimpleEnum {
+        VALUE_1, VALUE_2
+    }
+
+    enum EnumWithValueOverride {
+        VALUE_1("override_value_1"), VALUE_2("override_value_2");
+
+        private final String value;
+
+        EnumWithValueOverride(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+    }
+
+    enum EnumWithValueAndToStringOverride {
+        VALUE_1("override_value_1"), VALUE_2("override_value_2");
+
+        private final String value;
+
+        EnumWithValueAndToStringOverride(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
+    }
+
+    static Stream<Arguments> names() {
+        return Stream.of(
+                namesFor(SimpleEnum.class),
+                namesFor(EnumWithValueOverride.class),
+                namesFor(EnumWithValueAndToStringOverride.class)
+        ).flatMap(Function.identity());
+    }
+
+    static Stream<Arguments> lowerCaseNames() {
+        return Stream.of(
+                lowerCaseNamesFor(SimpleEnum.class),
+                lowerCaseNamesFor(EnumWithValueOverride.class),
+                lowerCaseNamesFor(EnumWithValueAndToStringOverride.class)
+        ).flatMap(Function.identity());
+    }
+
+    static Stream<String> invalid() {
+        return Stream.of("", "invalid", "INVALID");
+    }
+
+    private static <E extends Enum<E>> Stream<Arguments> namesFor(Class<E> type) {
+        return Stream.of(type.getEnumConstants())
+                .map(value -> Arguments.of(type, value, value.name()));
+    }
+
+    private static <E extends Enum<E>> Stream<Arguments> lowerCaseNamesFor(Class<E> type) {
+        return Stream.of(type.getEnumConstants())
+                .map(value -> Arguments.of(type, value, value.name().toLowerCase()));
+    }
+
+}

--- a/src/test/java/io/blt/util/EnTest.java
+++ b/src/test/java/io/blt/util/EnTest.java
@@ -42,7 +42,7 @@ class EnTest <E extends Enum<E>> {
 
     @Test
     void shouldBeValidUtilityClass() throws NoSuchMethodException {
-        assertValidUtilityClass(Obj.class);
+        assertValidUtilityClass(En.class);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Similar to Apache [`EnumUtils::getEnum`](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/EnumUtils.html#getEnum-java.lang.Class-java.lang.String-) and [`EnumUtils::getEnumIgnoreCase`](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/EnumUtils.html#getEnumIgnoreCase-java.lang.Class-java.lang.String-E-), but returns an `Optional` instead of `null` when the name cannot be found.
e.g., 

```java
of(DayOfWeek.class, "FRIDAY");    // Optional.of(DayOfWeek.FRIDAY)
of(DayOfWeek.class, "friday");    // Optional.empty()
of(DayOfWeek.class, "Worf");      // Optional.empty()
of(DayOfWeek.class, "");          // Optional.empty()
```

```java
ofIgnoreCase(DayOfWeek.class, "FRIDAY");    // Optional.of(DayOfWeek.FRIDAY)
ofIgnoreCase(DayOfWeek.class, "friday");    // Optional.of(DayOfWeek.FRIDAY)
```